### PR TITLE
bs - add fixtures for grocery objects

### DIFF
--- a/frontend/src/fixtures/groceryFixtures.js
+++ b/frontend/src/fixtures/groceryFixtures.js
@@ -1,0 +1,38 @@
+const groceryFixtures = {
+    oneGrocery:
+    [
+      {
+       "id": 1,
+        "name": "Milk",
+        "price": "4.99",
+        "expiration": "05/01/23" 
+      }
+    ],
+
+    threeGroceries:
+    [
+        {
+            "id": 2,
+            "name": "Banana",
+            "price": "0.19",
+            "expiration": "05/10/23" 
+        },
+
+        {
+            "id": 3,
+            "name": "Sandwich",
+            "price": "5.99",
+            "expiration": "04/28/23" 
+        },
+
+        {
+            "id": 4,
+            "name": "Eggs",
+            "price": "3.69",
+            "expiration": "06/01/23" 
+        },
+        
+    ]
+};
+
+export { groceryFixtures };


### PR DESCRIPTION
In this PR, we add fixtures for grocery objects to be used in testing and storybook entries.
